### PR TITLE
feat: Setup Browser Feature Detection

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build MDN BCD Page
         run: |
-          pip install requests
+          git clone https://github.com/mdn/browser-compat-data/.git
           python ./python/build_mdn_bcd.py ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
 
       - name: Build Test

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build MDN BCD Page
         run: |
-          git clone https://github.com/mdn/browser-compat-data/.git
+          git clone https://github.com/mdn/browser-compat-data.git
           python ./python/build_mdn_bcd.py ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
 
       - name: Build Test

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -61,13 +61,81 @@ jobs:
         run: |
           wget https://chromestatus.com/data/csspopularity -O ./static/google-css-popularity.json
 
-      
+      # Prepare MDN BCD collector
+      - name: Set LIBCLANG_PATH env
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Clone Repository
+        uses: actions/checkout@v4
+      - name: Clone mdn-bcd-collector
+        uses: actions/checkout@v4
+        with:
+          repository: openwebdocs/mdn-bcd-collector
+          submodules: true
+          path: collector
+      - name: Clone Servo
+        uses: actions/checkout@v4
+        with:
+          repository: servo/servo
+          path: servo
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.6"
+      - name: Build Servo
+        run: |
+          cd servo
+          ./mach bootstrap
+          ./mach build
+      - name: Run MDN bcd collector in background
+        run: |
+          cd collector
+          npm ci
+          nohup npm run dev &
+
+          retries=15
+          count=0
+          until curl -s http://localhost:5200 > /dev/null; do
+            if [ $count -ge $retries ]; then
+              echo "Server did not start after $retries attempts."
+              exit 1
+            fi
+            echo "Retry $((count + 1))/$retries: Server not ready, retrying in 2 seconds..."
+            sleep 2
+            count=$((count + 1))
+          done
+
+          echo "Server is up!"
+      - name: Run test and generate report
+        run: |
+          cd servo
+          # Run the test in headless modeand save the output to a variable
+          OUTPUT=$(timeout 10m ./mach run http://localhost:5200/tests/ --headless --userscripts="${{ github.workspace }}/scripts/")
+
+          # Extract the line with "RESULT_FILENAME:" and isolate the filename
+          FILENAME=$(echo "$OUTPUT" | grep "RESULT_FILENAME:" | sed 's/RESULT_FILENAME: //')
+
+          echo "Result filename: $FILENAME"
+
+          # Save to environment for later steps
+          echo "RESULT_FILENAME=$FILENAME" >> $GITHUB_ENV
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RESULT_FILENAME }}
+          path: ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12' 
+          
       - name:
         run: |
           python ./python/build_css.py
+          python ./python/build_mdn_bcd.py ${{ env.RESULT_FILENAME }}
 
       - name: Build Test
         if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'preview-build')

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -132,9 +132,13 @@ jobs:
         with:
           python-version: '3.12' 
           
-      - name:
+      - name: Build CSS Page
         run: |
           python ./python/build_css.py
+
+      - name: Build MDN BCD Page
+        run: |
+          pip install requests
           python ./python/build_mdn_bcd.py ${{ env.RESULT_FILENAME }}
 
       - name: Build Test

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Build MDN BCD Page
         run: |
           git clone https://github.com/mdn/browser-compat-data.git
-          python ./python/build_mdn_bcd.py ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
+          python ./python/build_browser_feature.py ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
 
       - name: Build Test
         if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'preview-build')

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   setup-and-deploy:
     permissions: write-all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Build MDN BCD Page
         run: |
           pip install requests
-          python ./python/build_mdn_bcd.py ${{ env.RESULT_FILENAME }}
+          python ./python/build_mdn_bcd.py ${{ github.workspace }}/collector/download/${{ env.RESULT_FILENAME }}
 
       - name: Build Test
         if: github.ref != 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'preview-build')

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ Currently the only thing that's being tracked is the CSS feature coverage of `Se
 
 ## How it works
 
+### CSS Popularity Coverage
+
 The [chromestatus](https://chromestatus.com/metrics/css/popularity#variable) collects the most used css properties via Chrome's anonymous usage statistics, while `Servo` currently generates the [supported css properties page](https://doc.servo.org/stylo/css-properties.html) in its `Stylo` component documentation.
 
 This simple page just loads and parse through the data and list out the supported css features of `Servo`.
+
+### Browser Feature Coverage
+
+The project [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com/) provides a full host of testing suite to check the features supported by a browser. We will run the latest Servo commit to perform this test locally, then retrieve links to relevant specs with [mdn's browser-compat-data](https://github.com/mdn/browser-compat-data).
+
 
 ## Future Work
 
@@ -16,6 +23,6 @@ This simple page just loads and parse through the data and list out the supporte
 - [x] Rework to be built with Zola
 - [x] Automatic rebuilding every week
 - [x] Host the page on a better domain
-- [ ] Add in supported HTML/JS API tracking
+- [x] Add in supported HTML/JS API tracking
 - [x] Improve frontend presentation
 - [ ] Add in performance tracking

--- a/config.toml
+++ b/config.toml
@@ -159,7 +159,8 @@ links = [
 		# { url = "@/mods/index.md", name = "Mods" }
 	# ] },
 	# { url = "@/blog/_index.md", name = "Blog" },
-	{ url = "@/metrics/css.md", name = "CSS Coverage" },
+	{ url = "@/metrics/css.md", name = "CSS Popularity Coverage" },
+	{ url = "@/metrics/browser-feature.md", name = "Browser Feature Coverage" },
 	# { url = "https://daudix.one/coffee/", name = "Coffee" }
 ]
 

--- a/content/metrics/browser-feature.md
+++ b/content/metrics/browser-feature.md
@@ -5,4 +5,4 @@ title = "Browser Feature Coverage"
 
 This page will be automatically built every week showing the status of supported browser feature.
 
-The data is generated using json file retreived by running latest servo build through local instance of [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com/) which performs browser feature detection, and will then be compared with [mdn's browser-compat-data](https://github.com/mdn/browser-compat-data) to link relevant specs.
+The data is generated using json file retreived by running latest Servo commit through a local instance of [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com/) which performs browser feature detection. Then relevant links of specs will be retrieved through [mdn's browser-compat-data](https://github.com/mdn/browser-compat-data).

--- a/content/metrics/browser-feature.md
+++ b/content/metrics/browser-feature.md
@@ -1,0 +1,8 @@
++++
+insert_anchor_links = "left"
+title = "Browser Feature Coverage"
++++
+
+This page will be automatically built every week showing the status of supported browser feature.
+
+The data is generated using json file retreived by running latest servo build through local instance of [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com/) which performs browser feature detection, and will then be compared with [mdn's browser-compat-data](https://github.com/mdn/browser-compat-data) to link relevant specs.

--- a/content/metrics/css.md
+++ b/content/metrics/css.md
@@ -1,6 +1,6 @@
 +++
 insert_anchor_links = "left"
-title = "Stylo CSS Coverage"
+title = "Stylo CSS Popularity Coverage"
 +++
 
 This page will be automatically built every week showing the status of supported CSS features in [Stylo](https://github.com/servo/stylo), the styling system of Servo.

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -38,7 +38,7 @@ def read_json_file(file_path):
 
             url = get_url_from_bcd(name)
             spec_links = []
-            if url and url[0]
+            if url and url[0]:
                 spec_links.append(f"[MDN]({url[0]})")
             if url and isinstance(url[1], list):
                 i = 0
@@ -47,7 +47,7 @@ def read_json_file(file_path):
                     i += 1
             elif url and url[1]:
                 spec_links.append(f"[SPEC]({url[1]})")
-            links = ", ".join(spec_links) if spec_links else "N/A"
+            links = ", ".join(spec_links) if len(spec_links) > 0 else "N/A"
 
             md_lines.append(f"| `{name}` | {icon} | {exposure} | {links} |")
 

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import os
 import sys
 
-# === CONFIG: Path to your local BCD repo clone ===
 BCD_REPO_PATH = "./browser-compat-data/"
 
 def read_json_file(file_path):
@@ -50,10 +49,6 @@ def read_json_file(file_path):
         f.write("\n".join(md_lines))
 
 def get_url_from_bcd(api_path):
-    """Look up the spec_url for a given API path using a local BCD repo."""
-    if api_path in spec_cache:
-        return spec_cache[api_path]
-
     parts = api_path.split(".")  # skip 'api' prefix
     if not parts:
         return None

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -37,7 +37,7 @@ def read_json_file(file_path):
             icon = "✅" if result is True else "❌" if result is False else "⚠️"
 
             url = get_url_from_bcd(name)
-            mdn_md = f"[MDN]({url[2]})" if url and url[2] else "-"
+            mdn_md = f"[MDN]({url[0]})" if url and url[0] else "-"
             spec_md = f"[SPEC]({url[1]})" if url and url[1] else "-"
 
             md_lines.append(f"| `{name}` | {icon}| {exposure} | {mdn_md}, {spec_md} |")
@@ -75,7 +75,7 @@ def get_url_from_bcd(api_path):
 
         mdn_url = current.get("__compat").get("mdn_url")
         spec_url = current.get("__compat").get("spec_url")
-        return (spec_url, mdn_url)
+        return (mdn_url, spec_url)
 
     except Exception as e:
         print(f"Error reading BCD for {api_path}: {e}")

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -64,10 +64,7 @@ def get_url_from_bcd(api_path):
     if not parts:
         return None
     # Construct the path with all parts joined by '/' except the last part
-    # which will be the key used to find spec_url in the BCD JSON
-    key = parts[-1]
-    parts = parts[:-1]  # Remove the last part for the directory structure
-    root_file = "/".join(parts) + ".json"
+    root_file = "/".join(parts[:-1]) + ".json"
     bcd_path = os.path.join(BCD_REPO_PATH, root_file)
 
     if not os.path.isfile(bcd_path):

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -38,7 +38,16 @@ def read_json_file(file_path):
 
             url = get_url_from_bcd(name)
             mdn_md = f"[MDN]({url[0]})" if url and url[0] else "-"
-            spec_md = f"[SPEC]({url[1]})" if url and url[1] else "-"
+            spec_md = ""
+            i = 0
+            if url[1] is list:
+                for spec in url[1]:
+                    spec_md += f"[SPEC{i}]({spec})"
+                    i += 1
+                    if i < len(url[1]):
+                        spec_md += ", "
+            else:
+                spec_md = f"[SPEC]({url[1]})" if url and url[1] else "-"
 
             md_lines.append(f"| `{name}` | {icon}| {exposure} | {mdn_md}, {spec_md} |")
 

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -33,16 +33,17 @@ def read_json_file(file_path):
 
     for group in sorted(grouped):
         md_lines.append(f"### `{group}` APIs\n")
-        md_lines.append("| API Feature | Result | Exposure | Source | Spec URL |")
-        md_lines.append("|-------------|--------|----------|--------|----------|")
+        md_lines.append("| API Feature | Result | Exposure | MDN URL | Spec URL |")
+        md_lines.append("|-------------|--------|----------|---------|----------|")
 
         for name, result, exposure, url in grouped[group]:
             icon = "✅" if result is True else "❌" if result is False else "⚠️"
 
-            spec_url = get_spec_url_from_bcd(name)
-            spec_md = f"[spec]({spec_url})" if spec_url else "-"
+            (mdn_url, spec_url) = get_url_from_bcd(name)
+            spec_md = f"[SPEC]({spec_url})" if spec_url else "-"
+            mdn_md = f"[MDN]({mdn_url})" if mdn_url else "-"
 
-            md_lines.append(f"| `{name}` | {icon}| {spec_md} |")
+            md_lines.append(f"| `{name}` | {icon}| {mdn_md} | {spec_md} |")
 
         md_lines.append("")  # Blank line between groups
 
@@ -50,7 +51,7 @@ def read_json_file(file_path):
     with open("./content/metrics/browser-feature.md", "a", encoding="utf-8") as f:
         f.write("\n".join(md_lines))
 
-def get_spec_url_from_bcd(api_path):
+def get_url_from_bcd(api_path):
     """Look up the spec_url for a given API path using a local BCD repo."""
     if api_path in spec_cache:
         return spec_cache[api_path]
@@ -80,9 +81,10 @@ def get_spec_url_from_bcd(api_path):
                 current = None
                 break
 
+        mdn_url = current.get("__compat").get("mdn_url")
         spec_url = current.get("__compat").get("spec_url")
         spec_cache[api_path] = spec_url
-        return spec_url
+        return (spec_url, mdn_url)
 
     except Exception as e:
         print(f"Error reading BCD for {api_path}: {e}")

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -40,14 +40,16 @@ def read_json_file(file_path):
             mdn_md = f"[MDN]({url[0]})" if url and url[0] else "-"
             spec_md = ""
             i = 0
-            if url[1] is list:
+            if url and url[1] is list:
                 for spec in url[1]:
                     spec_md += f"[SPEC{i}]({spec})"
                     i += 1
                     if i < len(url[1]):
                         spec_md += ", "
-            else:
+            elif url and url[1]:
                 spec_md = f"[SPEC]({url[1]})" if url and url[1] else "-"
+            else:
+                spec_md = "-"
 
             md_lines.append(f"| `{name}` | {icon}| {exposure} | {mdn_md}, {spec_md} |")
 

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -37,21 +37,19 @@ def read_json_file(file_path):
             icon = "✅" if result is True else "❌" if result is False else "⚠️"
 
             url = get_url_from_bcd(name)
-            mdn_md = f"[MDN]({url[0]})" if url and url[0] else "-"
-            spec_md = ""
-            i = 0
+            spec_links = []
+            if url and url[0]
+                spec_links.append(f"[MDN]({url[0]})")
             if url and isinstance(url[1], list):
+                i = 0
                 for spec in url[1]:
-                    spec_md += f"[SPEC{i}]({spec})"
+                    spec_links.append(f"[SPEC{i}]({spec})")
                     i += 1
-                    if i < len(url[1]):
-                        spec_md += ", "
             elif url and url[1]:
-                spec_md = f"[SPEC]({url[1]})" if url and url[1] else "-"
-            else:
-                spec_md = "-"
+                spec_links.append(f"[SPEC]({url[1]})")
+            links = ", ".join(spec_links) if spec_links else "N/A"
 
-            md_lines.append(f"| `{name}` | {icon}| {exposure} | {mdn_md}, {spec_md} |")
+            md_lines.append(f"| `{name}` | {icon} | {exposure} | {links} |")
 
         md_lines.append("")  # Blank line between groups
 

--- a/python/build_browser_feature.py
+++ b/python/build_browser_feature.py
@@ -40,7 +40,7 @@ def read_json_file(file_path):
             mdn_md = f"[MDN]({url[0]})" if url and url[0] else "-"
             spec_md = ""
             i = 0
-            if url and url[1] is list:
+            if url and isinstance(url[1], list):
                 for spec in url[1]:
                     spec_md += f"[SPEC{i}]({spec})"
                     i += 1

--- a/python/build_css.py
+++ b/python/build_css.py
@@ -26,7 +26,7 @@ def generate_line(data):
     if data['servo_supports'] == "supported":
         line += f" | ✅"
     elif data['servo_supports'] == "experimental":
-        line += f" | 🧪"
+        line += f" | ⚠️"
     else:
         line += f" | ❌"
     # display the relevant specs for the property

--- a/python/build_mdn_bcd.py
+++ b/python/build_mdn_bcd.py
@@ -2,6 +2,7 @@ import json
 from collections import defaultdict
 import requests
 import os
+import sys
 
 
 def read_json_file(file_path):

--- a/python/build_mdn_bcd.py
+++ b/python/build_mdn_bcd.py
@@ -1,16 +1,19 @@
 import json
 from collections import defaultdict
-import requests
 import os
 import sys
 
+# === CONFIG: Path to your local BCD repo clone ===
+BCD_REPO_PATH = "./browser-compat-data/api"
+# Cache spec URLs to avoid redundant reads
+spec_cache = {}
 
 def read_json_file(file_path):
-    # Load JSON file
+    # Load test results JSON file
     with open(file_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    # Prepare grouped results by API category
+    # Organize test data by API group
     grouped = defaultdict(list)
     results = data.get("results", {})
 
@@ -20,53 +23,12 @@ def read_json_file(file_path):
             result = test.get("result", "N/A")
             exposure = test.get("exposure", "N/A")
 
-            # Extract group name (e.g., api.Animation.* -> Animation)
             parts = name.split(".")
-            if len(parts) > 1:
-                group = parts[1]
-            else:
-                group = "Misc"
+            group = parts[1] if len(parts) > 1 else "Misc"
 
             grouped[group].append((name, result, exposure, url))
 
-    # Cache for BCD spec URLs to reduce repeated network requests
-    spec_cache = {}
-
-    def fetch_spec_url(api_path):
-        """Try to get spec URL from MDN BCD JSON via GitHub raw content."""
-        if api_path in spec_cache:
-            return spec_cache[api_path]
-
-        parts = api_path.split(".")[1:]  # skip 'api' prefix
-        if not parts:
-            return None
-
-        # Build URL to raw JSON file
-        file_path = "/".join(parts[:1])  # e.g., 'Animation'
-        json_url = f"https://raw.githubusercontent.com/mdn/browser-compat-data/main/api/{file_path}.json"
-
-        try:
-            res = requests.get(json_url)
-            if res.status_code != 200:
-                spec_cache[api_path] = None
-                return None
-
-            bcd_json = res.json()
-            current = bcd_json.get("api", {})
-            for part in parts:
-                current = current.get(part)
-                if current is None:
-                    break
-
-            spec_url = current.get("spec_url") if isinstance(current, dict) else None
-            spec_cache[api_path] = spec_url
-            return spec_url
-
-        except Exception:
-            spec_cache[api_path] = None
-            return None
-
-    # Generate Markdown
+    # Generate Markdown output
     md_lines = ["# API Compatibility Results (Grouped + Spec URL)\n"]
 
     for group in sorted(grouped):
@@ -75,25 +37,55 @@ def read_json_file(file_path):
         md_lines.append("|-------------|--------|----------|--------|----------|")
 
         for name, result, exposure, url in grouped[group]:
-            if result is True:
-                icon = "✅"
-            elif result is False:
-                icon = "❌"
-            elif result is None:
-                icon = "⚠️"
-            else:
-                icon = str(result)
+            icon = "✅" if result is True else "❌" if result is False else "⚠️"
 
-            spec_url = fetch_spec_url(name)
+            spec_url = get_spec_url_from_bcd(name)
             spec_md = f"[spec]({spec_url})" if spec_url else "-"
-            md_lines.append(f"| `{name}` | {icon} | `{exposure}` | [test]({url}) | {spec_md} |")
 
-        md_lines.append("")
+            md_lines.append(f"| `{name}` | {icon}| {spec_md} |")
 
-    # Save to markdown
-    with open('./content/metrics/css.md', 'a', encoding='utf-8') as file:
-        file.write("\n".join(md_lines))
+        md_lines.append("")  # Blank line between groups
 
+    # Save output
+    with open("./content/metrics/browser-feature.md", "w", encoding="utf-8") as f:
+        f.write("\n".join(md_lines))
+
+def get_spec_url_from_bcd(api_path):
+    """Look up the spec_url for a given API path using a local BCD repo."""
+    if api_path in spec_cache:
+        return spec_cache[api_path]
+
+    parts = api_path.split(".")[1:]  # skip 'api' prefix
+    if not parts:
+        return None
+    root_file = "/".join(parts) + ".json"
+    bcd_path = os.path.join(BCD_REPO_PATH, root_file)
+    print(f"bcd_path")
+
+    if not os.path.isfile(bcd_path):
+        spec_cache[api_path] = None
+        return None
+
+    try:
+        with open(bcd_path, "r", encoding="utf-8") as f:
+            bcd_data = json.load(f)
+
+        current = bcd_data.get("api", {})
+        for part in parts:
+            if part in current:
+                current = current[part]
+            else:
+                current = None
+                break
+
+        spec_url = current.get("spec_url") if isinstance(current, dict) else None
+        spec_cache[api_path] = spec_url
+        return spec_url
+
+    except Exception as e:
+        print(f"Error reading BCD for {api_path}: {e}")
+        spec_cache[api_path] = None
+        return None
 
 def main(file_path):
     read_json_file(file_path)

--- a/python/build_mdn_bcd.py
+++ b/python/build_mdn_bcd.py
@@ -58,6 +58,10 @@ def get_spec_url_from_bcd(api_path):
     parts = api_path.split(".")[1:]  # skip 'api' prefix
     if not parts:
         return None
+    # Construct the path with all parts joined by '/' except the last part
+    # which will be the key used to find spec_url in the BCD JSON
+    key = parts[-1]
+    parts = parts[:-1]  # Remove the last part for the directory structure
     root_file = "/".join(parts) + ".json"
     bcd_path = os.path.join(BCD_REPO_PATH, root_file)
     print(f"bcd_path")
@@ -65,8 +69,9 @@ def get_spec_url_from_bcd(api_path):
     if not os.path.isfile(bcd_path):
         spec_cache[api_path] = None
         return None
-
+        print(f"path {bcd_path} not found, skipping")
     try:
+        print(f"path {bcd_path} found")
         with open(bcd_path, "r", encoding="utf-8") as f:
             bcd_data = json.load(f)
 

--- a/python/build_mdn_bcd.py
+++ b/python/build_mdn_bcd.py
@@ -1,0 +1,102 @@
+import json
+from collections import defaultdict
+import requests
+import os
+
+
+def read_json_file(file_path):
+    # Load JSON file
+    with open(file_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Prepare grouped results by API category
+    grouped = defaultdict(list)
+    results = data.get("results", {})
+
+    for url, tests in results.items():
+        for test in tests:
+            name = test.get("name", "N/A")
+            result = test.get("result", "N/A")
+            exposure = test.get("exposure", "N/A")
+
+            # Extract group name (e.g., api.Animation.* -> Animation)
+            parts = name.split(".")
+            if len(parts) > 1:
+                group = parts[1]
+            else:
+                group = "Misc"
+
+            grouped[group].append((name, result, exposure, url))
+
+    # Cache for BCD spec URLs to reduce repeated network requests
+    spec_cache = {}
+
+    def fetch_spec_url(api_path):
+        """Try to get spec URL from MDN BCD JSON via GitHub raw content."""
+        if api_path in spec_cache:
+            return spec_cache[api_path]
+
+        parts = api_path.split(".")[1:]  # skip 'api' prefix
+        if not parts:
+            return None
+
+        # Build URL to raw JSON file
+        file_path = "/".join(parts[:1])  # e.g., 'Animation'
+        json_url = f"https://raw.githubusercontent.com/mdn/browser-compat-data/main/api/{file_path}.json"
+
+        try:
+            res = requests.get(json_url)
+            if res.status_code != 200:
+                spec_cache[api_path] = None
+                return None
+
+            bcd_json = res.json()
+            current = bcd_json.get("api", {})
+            for part in parts:
+                current = current.get(part)
+                if current is None:
+                    break
+
+            spec_url = current.get("spec_url") if isinstance(current, dict) else None
+            spec_cache[api_path] = spec_url
+            return spec_url
+
+        except Exception:
+            spec_cache[api_path] = None
+            return None
+
+    # Generate Markdown
+    md_lines = ["# API Compatibility Results (Grouped + Spec URL)\n"]
+
+    for group in sorted(grouped):
+        md_lines.append(f"### `{group}` APIs\n")
+        md_lines.append("| API Feature | Result | Exposure | Source | Spec URL |")
+        md_lines.append("|-------------|--------|----------|--------|----------|")
+
+        for name, result, exposure, url in grouped[group]:
+            if result is True:
+                icon = "✅"
+            elif result is False:
+                icon = "❌"
+            elif result is None:
+                icon = "⚠️"
+            else:
+                icon = str(result)
+
+            spec_url = fetch_spec_url(name)
+            spec_md = f"[spec]({spec_url})" if spec_url else "-"
+            md_lines.append(f"| `{name}` | {icon} | `{exposure}` | [test]({url}) | {spec_md} |")
+
+        md_lines.append("")
+
+    # Save to markdown
+    with open('./content/metrics/css.md', 'a', encoding='utf-8') as file:
+        file.write("\n".join(md_lines))
+
+
+def main(file_path):
+    read_json_file(file_path)
+
+if __name__ == '__main__':
+    file_path = sys.argv[1]
+    main(file_path)

--- a/python/build_mdn_bcd.py
+++ b/python/build_mdn_bcd.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 # === CONFIG: Path to your local BCD repo clone ===
-BCD_REPO_PATH = "./browser-compat-data/api"
+BCD_REPO_PATH = "./browser-compat-data/"
 # Cache spec URLs to avoid redundant reads
 spec_cache = {}
 
@@ -47,7 +47,7 @@ def read_json_file(file_path):
         md_lines.append("")  # Blank line between groups
 
     # Save output
-    with open("./content/metrics/browser-feature.md", "w", encoding="utf-8") as f:
+    with open("./content/metrics/browser-feature.md", "a", encoding="utf-8") as f:
         f.write("\n".join(md_lines))
 
 def get_spec_url_from_bcd(api_path):
@@ -55,7 +55,7 @@ def get_spec_url_from_bcd(api_path):
     if api_path in spec_cache:
         return spec_cache[api_path]
 
-    parts = api_path.split(".")[1:]  # skip 'api' prefix
+    parts = api_path.split(".")  # skip 'api' prefix
     if not parts:
         return None
     # Construct the path with all parts joined by '/' except the last part
@@ -64,26 +64,23 @@ def get_spec_url_from_bcd(api_path):
     parts = parts[:-1]  # Remove the last part for the directory structure
     root_file = "/".join(parts) + ".json"
     bcd_path = os.path.join(BCD_REPO_PATH, root_file)
-    print(f"bcd_path")
 
     if not os.path.isfile(bcd_path):
         spec_cache[api_path] = None
         return None
-        print(f"path {bcd_path} not found, skipping")
     try:
-        print(f"path {bcd_path} found")
         with open(bcd_path, "r", encoding="utf-8") as f:
             bcd_data = json.load(f)
 
-        current = bcd_data.get("api", {})
-        for part in parts:
+        current = bcd_data.get(parts[0], {})
+        for part in parts[1:]:
             if part in current:
                 current = current[part]
             else:
                 current = None
                 break
 
-        spec_url = current.get("spec_url") if isinstance(current, dict) else None
+        spec_url = current.get("__compat").get("spec_url")
         spec_cache[api_path] = spec_url
         return spec_url
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,72 @@
+// After mdn-bcd-collector's tests page is loaded, run the test.
+onload = () => {
+  // collector will generate a script based on the test environment settings.
+  // We only need the parameters from the script and call the bcd.go function by ourselves.
+  let run_str = document.getElementById('run').onclick.toString();
+  const resourceCount = extractResourceCount(run_str);
+
+  bcd.go(onBcdTestComplete, resourceCount, true, {
+    name: 'servo',
+    version: '1',
+  });
+};
+
+async function onBcdTestComplete(results) {
+  await sendTestResults(results);
+  await exportReport();
+
+  // Close the window to terminate the servo process.
+  window.close();
+}
+
+function extractResourceCount(input) {
+  const match = input.match(/undefined,\s*(\d+),/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+// Send test results to collector.
+// Collector will store the results in its session storage temporarily.
+async function sendTestResults(results) {
+  console.log('Beginning sending report to collector...');
+
+  const resultsURL =
+    (location.origin || location.protocol + '//' + location.host) +
+    '/api/results?for=' +
+    encodeURIComponent(location.href);
+
+  const response = await fetch(resultsURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    body: JSON.stringify(results),
+  });
+
+  if (response.ok) {
+    console.log('Report sent successfully');
+  } else {
+    console.error('Failed to send report:', response.statusText);
+  }
+}
+
+// Send export request to collector.
+// This will make collector generate a json report in the `collector/download/` directory.
+async function exportReport() {
+  console.log('Beginning report export...');
+
+  const resultsURL =
+    (location.origin || location.protocol + '//' + location.host) + '/export';
+
+  const response = await fetch(resultsURL, {
+    method: 'POST',
+  });
+
+  if (response.ok) {
+    console.log('Report exported successfully');
+    let responseText = await response.text();
+    let filename = responseText.match(/<a.*href="\/download\/(.*)"/)[1];
+    console.log(`RESULT_FILENAME: ${filename}`);
+  } else {
+    console.error('Failed to export report:', response.statusText);
+  }
+}


### PR DESCRIPTION
Fixes #8 

This PR introduces the capability for AreWeBrowserYet to automatically generate a report on currently supported features by running a local instance of [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com/) with the latest Servo commit. Relevant specs will be retrieved from [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) to provide easy access.

This PR cannot be made without the help of @pewsheen who worked on automating the testing process, big thanks!

There are still a lot of improvements to be made, namely a big long list of tables might not be the easiest way to read. But we can improve it down the road.